### PR TITLE
OTA-4594: use `make install` to copy build artifacts to prefix

### DIFF
--- a/aktualizr-dev.rb
+++ b/aktualizr-dev.rb
@@ -1,9 +1,7 @@
 class AktualizrDev < Formula
-  desc "C++ Client for HERE OTA Connect"
-  homepage ""
-  version = "2020.2"
-  url "https://github.com/advancedtelematic/aktualizr.git", :using => :git, :tag => "#{version}"
-  sha256 "782fa343c85be455d6e51bd774f3244e0dad093989ac9bb1d96215785f7e7314"
+  desc "C++ Client for HERE OTA Connect, current dev version"
+
+  head "https://github.com/advancedtelematic/aktualizr.git"
 
   depends_on "openssl@1.1"
   depends_on "curl-openssl"
@@ -15,24 +13,23 @@ class AktualizrDev < Formula
   depends_on "pkgconfig" => :build
   depends_on "python3" => :build
 
-  bottle do
-    cellar :any
-    sha256 "021255fc3b2b7409ab649adeb0abdb71efec564519ca7d0a6ad36d92abc9f8b6" => :catalina
-  end
+  keg_only "Don't interfere with a release version, this is current dev version of Aktualizr"
 
   def install
-    mkdir "build" do
-      system "cmake", "..", "-DBoost_USE_MULTITHREADED=ON", "-DOPENSSL_SSL_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libssl.dylib", "-DOPENSSL_CRYPTO_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libcrypto.dylib", *std_cmake_args
+   brew link --force  mkdir "build" do
+      git_revision = `git rev-parse --short HEAD`.chomp
+      system "cmake", "..",
+                      "-DAKTUALIZR_VERSION=dev-#{git_revision}",
+                      "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+                      "-DBoost_USE_MULTITHREADED=ON",
+                      "-DOPENSSL_SSL_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libssl.dylib",
+                      "-DOPENSSL_CRYPTO_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libcrypto.dylib",
+                      *std_cmake_args
 
-      system "make",  "-j#{ENV.make_jobs}"
-
-      system "mkdir", "-p", "#{bin}"
-      system "mkdir", "-p", "#{lib}"
-
-      system "cp", "./src/aktualizr_primary/aktualizr", "#{bin}/aktualizr-dev"
-      system "cp", "./src/libaktualizr/libaktualizr_lib.dylib", "#{lib}"
+      system "make", "install", "-j#{ENV.make_jobs}"
     end
   end
+
 
   test do
     system "#{bin}/aktualizr --help"

--- a/aktualizr.rb
+++ b/aktualizr.rb
@@ -23,16 +23,14 @@ class Aktualizr < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DBoost_USE_MULTITHREADED=ON", "-DOPENSSL_SSL_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libssl.dylib", "-DOPENSSL_CRYPTO_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libcrypto.dylib", *std_cmake_args
+      system "cmake", "..",
+                      "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+                      "-DBoost_USE_MULTITHREADED=ON",
+                      "-DOPENSSL_SSL_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libssl.dylib",
+                      "-DOPENSSL_CRYPTO_LIBRARY=#{Formula["openssl@1.1"].opt_prefix}/lib/libcrypto.dylib",
+                      *std_cmake_args
 
-      system "make",  "-j#{ENV.make_jobs}"
-
-      system "mkdir", "-p", "#{bin}"
-      system "mkdir", "-p", "#{lib}"
-
-      system "cp", "./src/aktualizr_primary/aktualizr", "#{bin}/aktualizr"
-      system "cp", "./src/libaktualizr/libaktualizr_lib.dylib", "#{lib}"
-
+      system "make", "install", "-j#{ENV.make_jobs}"
     end
   end
 


### PR DESCRIPTION
- `make install` instead of `cp` to copy build artifacts to the prefix directory
- don't install a bottle for the dev version
- make the aktualizr dev formula `head` and `keg_only`

Signed-off-by: Mykhaylo Sul <myk.sul@gmail.com>