### PR TITLE
OTA-4594: Restructure the formula to make bump-formula-pr happy

### DIFF
--- a/aktualizr.rb
+++ b/aktualizr.rb
@@ -1,31 +1,29 @@
 class Aktualizr < Formula
   desc "C++ Client for HERE OTA Connect"
   homepage "https://github.com/advancedtelematic/aktualizr.git"
-
-  head "https://github.com/advancedtelematic/aktualizr.git"
-
   version = "2020.3"
 
-  url "https://github.com/advancedtelematic/aktualizr.git", :using => :git, :tag => "#{version}"
+  url "https://github.com/advancedtelematic/aktualizr.git", :using => :git, :tag => "#{version}", :revision => "9f2cc5d7b026eb1a1404f0c77ef6cb9377245423"
+  head "https://github.com/advancedtelematic/aktualizr.git"
 
   # in case of --HEAD brewing the global version attribute will be equal to HEAD-<short-latest-commit-hash-of-master>
   # in case of stable/default brewing the global version will be equal to the latest release tag
-
-  depends_on "openssl@1.1"
-  depends_on "curl-openssl"
-  depends_on "asn1c"
-  depends_on "boost"
-  depends_on "cmake" => :build
-  depends_on "libarchive"
-  depends_on "libsodium"
-  depends_on "pkgconfig" => :build
-  depends_on "python3" => :build
 
   bottle do
     root_url "https://github.com/advancedtelematic/aktualizr/releases/download/2020.3"
     cellar :any
     sha256 "f42c799f7262f49a6debe2435254e14ef6bcc39b6168541a1fb09dffa6882f82" => :mojave
   end
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python" => :build
+  depends_on "asn1c"
+  depends_on "boost"
+  depends_on "curl-openssl"
+  depends_on "libarchive"
+  depends_on "libsodium"
+  depends_on "openssl@1.1"
 
   def install
     args = %W[


### PR DESCRIPTION
`bump-formula-pr`, that is used for creating a PR to update the formula, verifies if the formula is compliant with certain rules/conventions. This PR is aimed to make the formula compliant with these requirements so ``bump-formula-pr` won't fail during the execution of the release CI job.
Signed-off-by: Mike Sul <ext-mykhaylo.sul@here.com>