### PR TITLE
fixed CI

### DIFF
--- a/aktualizr.rb
+++ b/aktualizr.rb
@@ -21,7 +21,7 @@ class Aktualizr < Formula
   depends_on "python@3.8" => :build
   depends_on "asn1c"
   depends_on "boost"
-  depends_on "curl-openssl"
+  depends_on "curl"
   depends_on "libarchive"
   depends_on "libsodium"
   depends_on "openssl@1.1"
@@ -42,6 +42,6 @@ class Aktualizr < Formula
   end
 
   test do
-    system "#{bin}/aktualizr --help"
+    system "#{bin}/aktualizr", "--help"
   end
 end

--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
 
 brew-lint-formula:
   stage: test
-  script: brew audit aktualizr.rb
+  script: brew audit --except-cops=Sorbet/FalseSigil,Style/Documentation,Style/FrozenStringLiteralComment,Metrics/MethodLength aktualizr.rb
   tags:
     - osx
 


### PR DESCRIPTION
curl-openssl renamed to curl and fixed or disabled rubocop warnings that appears because homebrew make rules strictly

Signed-off-by: Anatoliy Odukha <aodukha@gmail.com>